### PR TITLE
Fix pdf_to_image closing doc

### DIFF
--- a/app.py
+++ b/app.py
@@ -101,13 +101,14 @@ def floor_to_unit(value, unit=100):
     return value // unit * unit
 
 def pdf_to_image(pdf_path, page_num, zoom=2.0):
-    doc = fitz.open(pdf_path)
-    if page_num >= len(doc):
-        return None
-    page = doc.load_page(page_num)
-    mat = fitz.Matrix(zoom, zoom)
-    pix = page.get_pixmap(matrix=mat)
-    return pix.tobytes("png")
+    """Return PNG bytes of the specified page or ``None`` if out of range."""
+    with fitz.open(pdf_path) as doc:
+        if page_num >= len(doc):
+            return None
+        page = doc.load_page(page_num)
+        mat = fitz.Matrix(zoom, zoom)
+        pix = page.get_pixmap(matrix=mat)
+        return pix.tobytes("png")
 
 
 def format_with_comma(key):


### PR DESCRIPTION
## Summary
- ensure `pdf_to_image` closes its PDF file

## Testing
- `python -m py_compile app.py history_manager.py notion_utils.py ltv_map.py`

------
https://chatgpt.com/codex/tasks/task_e_6840f0ec67ec8325bca19a33b03bc9df